### PR TITLE
Fixes links to css.cool on slide 53

### DIFF
--- a/slides-en.html
+++ b/slides-en.html
@@ -835,7 +835,7 @@
     <section class="slide" data-markdown>
       <script type="text/template">
         #Endless Style
-        ##Go to [css.cool](css.cool)
+        ##Go to [css.cool](http://css.cool)
 
         ![css.cool screenshot](framework/img/workshop/csscool.jpg)
 

--- a/slides-fr.html
+++ b/slides-fr.html
@@ -837,7 +837,7 @@
     <section class="slide" data-markdown>
       <script type="text/template">
         #Du style à l'infini
-        ##Allez sur le site [css.cool](css.cool).
+        ##Allez sur le site [css.cool](http://css.cool).
 
         ![Capture d'écran, css.cool](framework/img/workshop/csscool.jpg)
 


### PR DESCRIPTION
The links were broken in both the English and French slides. Both went to the local filesystem. The site does not have proper SSL certificates, so I left the links as HTTP.